### PR TITLE
Unbreak the rsync backend

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -211,7 +211,6 @@ except ImportError:
                 sys.stdout.flush()
 
 class RsyncBackend(object):
-
     def __init__(self,remote,ssh_port,ssh_user,options,objdir):
         self.verbose = verbose_stderr if os.environ.get('GIT_FAT_VERBOSE') else verbose_ignore
         self.remote = remote
@@ -221,13 +220,13 @@ class RsyncBackend(object):
         self.objdir = objdir
 
     def get_rsync_command(self,push):
-        (remote, ssh_port, ssh_user, options) = self.get_rsync()
         if push:
-            self.verbose('Pushing to %s' % (remote))
+            self.verbose('Pushing to %s' % (self.remote))
         else:
-            self.verbose('Pulling from %s' % (remote))
+            self.verbose('Pulling from %s' % (self.remote))
 
-        cmd = [b'rsync', b'--progress', b'--ignore-existing', b'--from0', b'--files-from=-']
+        cmd = [b'rsync', b'--progress', b'--ignore-existing', b'--from0',
+               b'--files-from=-']
         rshopts = b''
         if self.ssh_user:
             rshopts += b' -l ' + self.ssh_user


### PR DESCRIPTION
This fixes #3.  It is the minimum necessary to get things to work again.  We probably could use a more sophisticated mechanism that allows for falling back to different backends.

cc: @willkelleher