### PR TITLE
'publish' generates public access urls for files.

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -78,6 +78,17 @@ try:
                         os.remove(localfile)
                         raise
 
+        def publish(self,files):
+            bkt = self.get_bucket()
+            for file, realname in files:
+                localfile = os.path.abspath(os.path.join(self.objdir,file))
+                self.verbose('Getting object %s from s3 bucket %s' % (file,self.bucket))
+                k = Key(bkt)
+                k.key = file
+                k.make_public()
+                url = k.generate_url(0, query_auth=False)
+                print('%s => %s' % (realname, url))
+
         def push(self,files):
             bkt = self.get_bucket()
             for file in files:
@@ -518,6 +529,22 @@ class GitFat(object):
         self.backend.pull(files)
         self.checkout()
 
+    def cmd_publish(self, args):
+        'query the public URLs for files'
+        self.setup()
+        files = []
+        for arg in args:
+            if arg.startswith('-'):
+                continue
+            if os.path.exists(arg):
+                mode, blobsha1, stageno, filename = \
+                    subprocess.check_output(['git', 'ls-files', '-s', arg]).split()
+                stub = subprocess.check_output(['git', 'cat-file', 'blob', blobsha1]).splitlines()
+                digest, bytecount = self.decode(stub[0])
+                files.append((digest, arg))
+                
+        self.backend.publish(files)
+
     def parse_pull_patterns(self, args):
         if '--' not in args:
             return ['']
@@ -677,5 +704,7 @@ if __name__ == '__main__':
         fat.cmd_find(sys.argv[2:])
     elif cmd == 'index-filter':
         fat.cmd_index_filter(sys.argv[2:])
+    elif cmd == 'publish':
+        fat.cmd_publish(sys.argv[2:])
     else:
-        print('Usage: git fat [init|status|push|pull|gc|checkout|find|index-filter]', file=sys.stderr)
+        print('Usage: git fat [init|status|push|pull|gc|checkout|find|index-filter|publish]', file=sys.stderr)


### PR DESCRIPTION
This is only implemented in the S3 backend.

A way to link the stub file to its content would
ease integration into repo hosting systems, if that ever happens
in the future.

eg, adding an url at the end of the stub file?

Example usage:

```
yfeng1@edison02:~/mydesi> git fat publish *.ipynb
NotebookDemo.ipynb => https://imaginglss-git.s3.amazonaws.com/be0e701526c1b75b43df3c9fde4a7b02507d59af
test.ipynb => https://imaginglss-git.s3.amazonaws.com/da39a3ee5e6b4b0d3255bfef95601890afd80709
```
