### PR TITLE
Update error for requirement of S3BackEnd

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -146,7 +146,7 @@ except ImportError:
     class S3Backend(object):
 
         def __init__(self,bucket,key,secret,objdir):
-            raise RuntimeError("S3Backend requires boto.")
+            raise RuntimeError("S3Backend requires boto and filechunkio.")
 
 BLOCK_SIZE = 4096
 LARGE_FILE_SIZE = 4294967296    # consider > 4GBs is large file size(Current limitation in windows)


### PR DESCRIPTION
Recently git-fat has been improved/modified to support large file size (upto 8GB).
To do that git-fat required filechunkio library but the error message is not showing that correctly as below:
![image](https://user-images.githubusercontent.com/785177/39822255-53cffe58-53d4-11e8-8ba3-56be5fdf5662.png)

This PR just told user to make sure having both boto and filechunkio to make latest git-fat to work correctly.

//cc @dscherba @KhanhLanHuynh 
