### PR TITLE
Use '.' instead of '' to match any pathspec; needed by git >=2.16

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -512,6 +512,8 @@ class GitFat(object):
 
     def orphan_files(self, patterns=[]):
         'generator for all orphan placeholders in the working tree'
+        if not patterns or patterns == ['']:
+            patterns = ['.']
         for fname in subprocess.check_output(['git', 'ls-files', '-z'] + patterns).split('\x00')[:-1]:
             digest = self.decode_file(fname)[0]
             if digest:


### PR DESCRIPTION
//cc @dscherba @jstys92 @KhanhLanHuynh @DillonSkeehan 

Recently, we can not run `git fat pull` anymore because of warning or error with:
```
fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths
``` 

**Workaround solutions:**
- `git fat pull .` is not working.
- `git fat pull --all` is not a right syntax to pull all sequences from backend (S3) because `--all` is used (follow [documentation](https://github.com/PersonifyInc/git-fat#cloning-and-pulling) and [code](https://github.com/PersonifyInc/git-fat/blob/master/git-fat#L488-L491)) to pull all/full history or revision of the large file (fat objects):
    ```
    This command also accepts the --all option to pull full history, or a revision to pull selected history.
    ```
- The correct workaround to pull all file in HEAD is using either `git fat pull --` or `git fat pull -- .`

To avoid workaround solution and make `git fat pull` work for both git <=2.16 or git >=2.16 so this PR is to address that. We can do that by changing https://github.com/PersonifyInc/git-fat/blob/master/git-fat#L587 to 
```
    def parse_pull_patterns(self, args):
        if '--' not in args:
            return [] #<-- here is the change we can make
        else:
```
But at the same time, I've noticed the author has fixed that with this commit, so let simply use [what author provided](https://github.com/jedbrown/git-fat/commit/75fb63d034878cc5be2d4339e52bb6b6983d0626).